### PR TITLE
fix Core C6 state handling

### DIFF
--- a/zenstates.py
+++ b/zenstates.py
@@ -116,11 +116,11 @@ if args.pstate >= 0:
         writemsr(pstates[args.pstate], new)
 
 if args.cc6_enable:
-    writemsr(0xC0010292, readmsr(0xC0010292) | (1 << 32))
+    writemsr(0xC0010296, readmsr(0xC0010296) | ((1 << 22) | (1 << 14) | (1 << 6)))
     print('Enabling Core C6 state')
 
 if args.cc6_disable:
-    writemsr(0xC0010292, readmsr(0xC0010292) & ~(1 << 32))
+    writemsr(0xC0010296, readmsr(0xC0010296) & ~((1 << 22) | (1 << 14) | (1 << 6)))
     print('Disabling Core C6 state')
 
 if args.pc6_enable:


### PR DESCRIPTION
The code for CC6 was exactly the same as for PC6.
The change is based on the code in r4m0n/ZenStates-Linux and
cyring/CoreFreq.